### PR TITLE
`TypedDashMap::entry` takes immutable reference.

### DIFF
--- a/src/dashmap.rs
+++ b/src/dashmap.rs
@@ -498,7 +498,7 @@ where
     /// assert!(letters.get(&Key('y')).is_none());
     /// ```
     pub fn entry<K: 'static + TypedMapKey<Marker> + Send + Sync>(
-        &mut self,
+        &self,
         key: K,
     ) -> dashentry::Entry<'_, K, Marker, S>
     where


### PR DESCRIPTION
The `entry` API doesn't require a mutable reference to `self`.