### PR TITLE
Upgrade "dashmap" dependency from "5.5.3" to "6.1.0"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 clone = ["dyn-clone"]
 
 [dependencies]
-dashmap = { version = "5.5.3", optional = true }
+dashmap = { version = "6.1.0", optional = true }
 dyn-clone = { version = "1.0.17", optional = true }
 
 [package.metadata.docs.rs]

--- a/src/dashentry.rs
+++ b/src/dashentry.rs
@@ -1,5 +1,5 @@
 //! Entry type for TypedDashMap
-use std::{hash::BuildHasher, marker::PhantomData};
+use std::marker::PhantomData;
 
 use crate::bounds::{Bounds, HasBounds};
 use crate::typedvalue::TypedMapValue;
@@ -8,27 +8,25 @@ use crate::{dashmap::RefMut, typedkey::TypedKey};
 
 const INVALID_ENTRY: &str = "Broken TypedDashMap: invalid entry";
 
-pub struct OccupiedEntry<'a, K, KB, VB, Marker, S>
+pub struct OccupiedEntry<'a, K, KB, VB, Marker>
 where
     K: 'static + TypedMapKey<Marker>,
     KB: 'static + Bounds + HasBounds<K>,
     VB: 'static + Bounds + HasBounds<K::Value>,
-    S: BuildHasher,
 {
-    base: dashmap::mapref::entry::OccupiedEntry<'a, TypedKey<KB>, TypedMapValue<VB>, S>,
+    base: dashmap::mapref::entry::OccupiedEntry<'a, TypedKey<KB>, TypedMapValue<VB>>,
     _phantom: PhantomData<Marker>,
     _phantom_key: PhantomData<K>,
 }
 
-impl<'a, K, KB, VB, Marker, S> OccupiedEntry<'a, K, KB, VB, Marker, S>
+impl<'a, K, KB, VB, Marker> OccupiedEntry<'a, K, KB, VB, Marker>
 where
     K: 'static + TypedMapKey<Marker>,
     KB: 'static + Bounds + HasBounds<K>,
     VB: 'static + Bounds + HasBounds<K::Value>,
-    S: BuildHasher,
 {
     #[inline]
-    pub fn into_ref(self) -> RefMut<'a, Marker, K, KB, VB, S> {
+    pub fn into_ref(self) -> RefMut<'a, Marker, K, KB, VB> {
         let refmut = self.base.into_ref();
 
         RefMut(refmut, PhantomData, PhantomData)
@@ -81,24 +79,22 @@ where
     }
 }
 
-pub struct VacantEntry<'a, K, KB, VB, Marker, S>
+pub struct VacantEntry<'a, K, KB, VB, Marker>
 where
     K: 'static + TypedMapKey<Marker>,
     KB: 'static + Bounds + HasBounds<K>,
     VB: 'static + Bounds + HasBounds<K::Value>,
-    S: BuildHasher,
 {
-    base: dashmap::mapref::entry::VacantEntry<'a, TypedKey<KB>, TypedMapValue<VB>, S>,
+    base: dashmap::mapref::entry::VacantEntry<'a, TypedKey<KB>, TypedMapValue<VB>>,
     _phantom: PhantomData<Marker>,
     _phantom_key: PhantomData<K>,
 }
 
-impl<'a, K, KB, VB, Marker, S> VacantEntry<'a, K, KB, VB, Marker, S>
+impl<'a, K, KB, VB, Marker> VacantEntry<'a, K, KB, VB, Marker>
 where
     K: 'static + TypedMapKey<Marker>,
     KB: 'static + Bounds + HasBounds<K>,
     VB: 'static + Bounds + HasBounds<K::Value>,
-    S: BuildHasher,
 {
     #[inline]
     pub fn key(&self) -> &K {
@@ -111,7 +107,7 @@ where
     }
 
     #[inline]
-    pub fn insert(self, value: K::Value) -> RefMut<'a, Marker, K, KB, VB, S> {
+    pub fn insert(self, value: K::Value) -> RefMut<'a, Marker, K, KB, VB> {
         let value = TypedMapValue::from_value(value);
         let refmut = self.base.insert(value);
 
@@ -119,25 +115,23 @@ where
     }
 }
 
-pub enum Entry<'a, K, KB, VB, Marker, S>
+pub enum Entry<'a, K, KB, VB, Marker>
 where
     K: 'static + TypedMapKey<Marker>,
     KB: 'static + Bounds + HasBounds<K>,
     VB: 'static + Bounds + HasBounds<K::Value>,
-    S: BuildHasher,
 {
-    Occupied(OccupiedEntry<'a, K, KB, VB, Marker, S>),
-    Vacant(VacantEntry<'a, K, KB, VB, Marker, S>),
+    Occupied(OccupiedEntry<'a, K, KB, VB, Marker>),
+    Vacant(VacantEntry<'a, K, KB, VB, Marker>),
 }
 
-pub(crate) fn map_entry<Marker, K, KB, VB, S>(
-    entry: dashmap::mapref::entry::Entry<'_, TypedKey<KB>, TypedMapValue<VB>, S>,
-) -> Entry<'_, K, KB, VB, Marker, S>
+pub(crate) fn map_entry<Marker, K, KB, VB>(
+    entry: dashmap::mapref::entry::Entry<'_, TypedKey<KB>, TypedMapValue<VB>>,
+) -> Entry<'_, K, KB, VB, Marker>
 where
     K: 'static + TypedMapKey<Marker>,
     KB: 'static + Bounds + HasBounds<K>,
     VB: 'static + Bounds + HasBounds<K::Value>,
-    S: BuildHasher,
 {
     match entry {
         dashmap::mapref::entry::Entry::Occupied(base) => Entry::Occupied(OccupiedEntry {
@@ -153,15 +147,14 @@ where
     }
 }
 
-impl<'a, Marker, K, KB, VB, S> Entry<'a, K, KB, VB, Marker, S>
+impl<'a, Marker, K, KB, VB> Entry<'a, K, KB, VB, Marker>
 where
     K: 'static + TypedMapKey<Marker>,
     KB: 'static + Bounds + HasBounds<K>,
     VB: 'static + Bounds + HasBounds<K::Value>,
-    S: BuildHasher,
 {
     #[inline]
-    pub fn or_insert(self, default: K::Value) -> RefMut<'a, Marker, K, KB, VB, S> {
+    pub fn or_insert(self, default: K::Value) -> RefMut<'a, Marker, K, KB, VB> {
         match self {
             Self::Occupied(entry) => entry.into_ref(),
             Self::Vacant(entry) => entry.insert(default),
@@ -172,7 +165,7 @@ where
     pub fn or_insert_with<F: FnOnce() -> K::Value>(
         self,
         default: F,
-    ) -> RefMut<'a, Marker, K, KB, VB, S> {
+    ) -> RefMut<'a, Marker, K, KB, VB> {
         match self {
             Self::Occupied(entry) => entry.into_ref(),
             Self::Vacant(entry) => entry.insert(default()),
@@ -200,15 +193,14 @@ where
     }
 }
 
-impl<'a, Marker, K, KB, VB, S> Entry<'a, K, KB, VB, Marker, S>
+impl<'a, Marker, K, KB, VB> Entry<'a, K, KB, VB, Marker>
 where
     K: 'static + TypedMapKey<Marker>,
     K::Value: 'static + Default,
     KB: 'static + Bounds + HasBounds<K>,
     VB: 'static + Bounds + HasBounds<K::Value>,
-    S: BuildHasher,
 {
-    pub fn or_default(self) -> RefMut<'a, Marker, K, KB, VB, S> {
+    pub fn or_default(self) -> RefMut<'a, Marker, K, KB, VB> {
         match self {
             Self::Occupied(entry) => entry.into_ref(),
             Self::Vacant(entry) => entry.insert(Default::default()),

--- a/src/dashmap.rs
+++ b/src/dashmap.rs
@@ -261,7 +261,7 @@ where
     /// map.insert(Key(3), 4);
     /// assert_eq!(*map.get(&Key(3)).unwrap(), 4);
     /// ```
-    pub fn get<K>(&self, key: &K) -> Option<Ref<'_, Marker, K, KB, VB, S>>
+    pub fn get<K>(&self, key: &K) -> Option<Ref<'_, Marker, K, KB, VB>>
     where
         K: 'static + TypedMapKey<Marker>,
         KB: HasBounds<K>,
@@ -295,7 +295,7 @@ where
     /// *map.get_mut(&Key(3)).unwrap() = 5;
     /// assert_eq!(*map.get(&Key(3)).unwrap().value(), 5);
     /// ```
-    pub fn get_mut<K>(&self, key: &K) -> Option<RefMut<'_, Marker, K, KB, VB, S>>
+    pub fn get_mut<K>(&self, key: &K) -> Option<RefMut<'_, Marker, K, KB, VB>>
     where
         K: 'static + TypedMapKey<Marker>,
         KB: HasBounds<K>,
@@ -596,7 +596,7 @@ where
     /// assert_eq!(letters.get(&Key('u')).unwrap().value(), &1);
     /// assert!(letters.get(&Key('y')).is_none());
     /// ```
-    pub fn entry<K>(&self, key: K) -> dashentry::Entry<'_, K, KB, VB, Marker, S>
+    pub fn entry<K>(&self, key: K) -> dashentry::Entry<'_, K, KB, VB, Marker>
     where
         K: 'static + TypedMapKey<Marker>,
         KB: HasBounds<K>,
@@ -695,7 +695,7 @@ where
     VB: 'static + Bounds,
     S: BuildHasher + Clone,
 {
-    type Item = TypedKeyValueGuard<'a, Marker, KB, VB, S>;
+    type Item = TypedKeyValueGuard<'a, Marker, KB, VB>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let key_value = self.0.next()?;
@@ -706,16 +706,15 @@ where
     }
 }
 
-pub struct TypedKeyValueGuard<'a, Marker, KB: 'static + Bounds, VB: 'static + Bounds, S> {
-    key_value: dashmap::mapref::multiple::RefMulti<'a, TypedKey<KB>, TypedMapValue<VB>, S>,
+pub struct TypedKeyValueGuard<'a, Marker, KB: 'static + Bounds, VB: 'static + Bounds> {
+    key_value: dashmap::mapref::multiple::RefMulti<'a, TypedKey<KB>, TypedMapValue<VB>>,
     _marker: PhantomData<Marker>,
 }
 
-impl<Marker, KB, VB, S> TypedKeyValueGuard<'_, Marker, KB, VB, S>
+impl<Marker, KB, VB> TypedKeyValueGuard<'_, Marker, KB, VB>
 where
     KB: 'static + Bounds,
     VB: 'static + Bounds,
-    S: BuildHasher,
 {
     /// Downcast key to reference of `K`. Returns `None` if not possible.
     pub fn downcast_key_ref<K: 'static + TypedMapKey<Marker>>(&self) -> Option<&'_ K>
@@ -755,7 +754,7 @@ where
 }
 
 #[cfg(feature = "clone")]
-impl<M, KB: Bounds, VB: Bounds, S: BuildHasher> TypedKeyValueGuard<'_, M, KB, VB, S>
+impl<M, KB: Bounds, VB: Bounds> TypedKeyValueGuard<'_, M, KB, VB>
 where
     KB::KeyContainer: crate::clone::CloneAny,
     VB::Container: crate::clone::CloneAny,
@@ -837,7 +836,7 @@ where
     VB: 'static + Bounds,
     S: BuildHasher + Clone,
 {
-    type Item = TypedKeyValueMutGuard<'a, Marker, KB, VB, S>;
+    type Item = TypedKeyValueMutGuard<'a, Marker, KB, VB>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let key_value = self.0.next()?;
@@ -848,16 +847,15 @@ where
     }
 }
 
-pub struct TypedKeyValueMutGuard<'a, Marker, KB: 'static + Bounds, VB: 'static + Bounds, S> {
-    key_value: dashmap::mapref::multiple::RefMutMulti<'a, TypedKey<KB>, TypedMapValue<VB>, S>,
+pub struct TypedKeyValueMutGuard<'a, Marker, KB: 'static + Bounds, VB: 'static + Bounds> {
+    key_value: dashmap::mapref::multiple::RefMutMulti<'a, TypedKey<KB>, TypedMapValue<VB>>,
     _marker: PhantomData<Marker>,
 }
 
-impl<Marker, KB, VB, S> TypedKeyValueMutGuard<'_, Marker, KB, VB, S>
+impl<Marker, KB, VB> TypedKeyValueMutGuard<'_, Marker, KB, VB>
 where
     KB: 'static + Bounds,
     VB: 'static + Bounds,
-    S: BuildHasher,
 {
     /// Downcast key to reference of `K`. Returns `None` if not possible.
     pub fn downcast_key_ref<K: 'static + TypedMapKey<Marker>>(&self) -> Option<&'_ K>
@@ -921,7 +919,7 @@ where
 }
 
 #[cfg(feature = "clone")]
-impl<M, KB: Bounds, VB: Bounds, S: BuildHasher> TypedKeyValueMutGuard<'_, M, KB, VB, S>
+impl<M, KB: Bounds, VB: Bounds> TypedKeyValueMutGuard<'_, M, KB, VB>
 where
     KB::KeyContainer: crate::clone::CloneAny,
     VB::Container: crate::clone::CloneAny,
@@ -959,8 +957,8 @@ where
 }
 
 /// An immutable reference
-pub struct Ref<'a, Marker, K, KB, VB, S>(
-    dashmap::mapref::one::Ref<'a, TypedKey<KB>, TypedMapValue<VB>, S>,
+pub struct Ref<'a, Marker, K, KB, VB>(
+    dashmap::mapref::one::Ref<'a, TypedKey<KB>, TypedMapValue<VB>>,
     std::marker::PhantomData<K>,
     std::marker::PhantomData<Marker>,
 )
@@ -969,12 +967,11 @@ where
     KB: 'static + Bounds + HasBounds<K>,
     VB: 'static + Bounds + HasBounds<K::Value>;
 
-impl<Marker, K, KB, VB, S> Ref<'_, Marker, K, KB, VB, S>
+impl<Marker, K, KB, VB> Ref<'_, Marker, K, KB, VB>
 where
     K: 'static + TypedMapKey<Marker>,
     KB: 'static + Bounds + HasBounds<K>,
     VB: 'static + Bounds + HasBounds<K::Value>,
-    S: BuildHasher,
 {
     pub fn key(&self) -> &K {
         self.0.key().downcast_ref::<K>().expect(INVALID_KEY)
@@ -992,12 +989,11 @@ where
     }
 }
 
-impl<Marker, K, KB, VB, S> Deref for Ref<'_, Marker, K, KB, VB, S>
+impl<Marker, K, KB, VB> Deref for Ref<'_, Marker, K, KB, VB>
 where
     K: 'static + TypedMapKey<Marker>,
     KB: 'static + Bounds + HasBounds<K>,
     VB: 'static + Bounds + HasBounds<K::Value>,
-    S: BuildHasher,
 {
     type Target = K::Value;
 
@@ -1006,12 +1002,11 @@ where
     }
 }
 
-impl<Marker, K, KB, VB, S> Debug for Ref<'_, Marker, K, KB, VB, S>
+impl<Marker, K, KB, VB> Debug for Ref<'_, Marker, K, KB, VB>
 where
     K: 'static + TypedMapKey<Marker>,
     KB: 'static + Bounds + HasBounds<K>,
     VB: 'static + Bounds + HasBounds<K::Value>,
-    S: BuildHasher,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         f.write_str("Ref")
@@ -1019,23 +1014,21 @@ where
 }
 
 /// A mutable reference
-pub struct RefMut<'a, Marker, K, KB, VB, S>(
-    pub(crate) dashmap::mapref::one::RefMut<'a, TypedKey<KB>, TypedMapValue<VB>, S>,
+pub struct RefMut<'a, Marker, K, KB, VB>(
+    pub(crate) dashmap::mapref::one::RefMut<'a, TypedKey<KB>, TypedMapValue<VB>>,
     pub(crate) PhantomData<K>,
     pub(crate) PhantomData<Marker>,
 )
 where
     K: 'static + TypedMapKey<Marker>,
     KB: 'static + Bounds + HasBounds<K>,
-    VB: 'static + Bounds + HasBounds<K::Value>,
-    S: BuildHasher;
+    VB: 'static + Bounds + HasBounds<K::Value>;
 
-impl<Marker, K, KB, VB, S> RefMut<'_, Marker, K, KB, VB, S>
+impl<Marker, K, KB, VB> RefMut<'_, Marker, K, KB, VB>
 where
     K: 'static + TypedMapKey<Marker>,
     KB: 'static + Bounds + HasBounds<K>,
     VB: 'static + Bounds + HasBounds<K::Value>,
-    S: BuildHasher,
 {
     pub fn key(&self) -> &K {
         self.0.key().downcast_ref::<K>().expect(INVALID_KEY)
@@ -1067,12 +1060,11 @@ where
     }
 }
 
-impl<Marker, K, KB, VB, S> Deref for RefMut<'_, Marker, K, KB, VB, S>
+impl<Marker, K, KB, VB> Deref for RefMut<'_, Marker, K, KB, VB>
 where
     K: 'static + TypedMapKey<Marker>,
     KB: 'static + Bounds + HasBounds<K>,
     VB: 'static + Bounds + HasBounds<K::Value>,
-    S: BuildHasher,
 {
     type Target = K::Value;
 
@@ -1081,24 +1073,22 @@ where
     }
 }
 
-impl<Marker, K, KB, VB, S> DerefMut for RefMut<'_, Marker, K, KB, VB, S>
+impl<Marker, K, KB, VB> DerefMut for RefMut<'_, Marker, K, KB, VB>
 where
     K: 'static + TypedMapKey<Marker>,
     KB: 'static + Bounds + HasBounds<K>,
     VB: 'static + Bounds + HasBounds<K::Value>,
-    S: BuildHasher,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.value_mut()
     }
 }
 
-impl<Marker, K, KB, VB, S> Debug for RefMut<'_, Marker, K, KB, VB, S>
+impl<Marker, K, KB, VB> Debug for RefMut<'_, Marker, K, KB, VB>
 where
     K: 'static + TypedMapKey<Marker>,
     KB: 'static + Bounds + HasBounds<K>,
     VB: 'static + Bounds + HasBounds<K::Value>,
-    S: BuildHasher,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         f.write_str("RefMut")


### PR DESCRIPTION
This subsumes https://github.com/kodieg/typedmap/pull/14.

Once https://github.com/kodieg/typedmap/pull/15 is merged the remaining `clippy` warnings should disappear by themselves with a branch sync.